### PR TITLE
fix: add totalCount to show the number of rows

### DIFF
--- a/src/hooks/useTable/useTable.ts
+++ b/src/hooks/useTable/useTable.ts
@@ -121,6 +121,7 @@ function useTable<
       pages,
       currentPage,
       paginationType: pagination.type,
+      totalCount: pagination?.totalCount ?? 0,
     };
   }
 

--- a/src/hooks/useTable/useTable.types.ts
+++ b/src/hooks/useTable/useTable.types.ts
@@ -47,6 +47,7 @@ interface IPaginationData {
   pages: number[];
   currentPage: number;
   paginationType?: "custom";
+  totalCount?: number;
 }
 
 type IColumnsData = {


### PR DESCRIPTION
# Description

Add `totalCount` props to show the number of rows. Now the `totalCount` is returned from the `useTable` hook.