### PR TITLE
fix: adjust column hiding

### DIFF
--- a/src/__mocks__/mockColumns.ts
+++ b/src/__mocks__/mockColumns.ts
@@ -26,7 +26,7 @@ const mockColumns = [
     render: (data: Record<string, unknown>) => `Mr. ${data.last_name}`,
   },
   { label: "Email", id: "email" },
-  { label: "Gender", id: "gender" },
+  { label: "Gender", id: "gender", hidden: true },
   { label: "IP Address", id: "ip_address", sortable: false },
 ];
 

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -176,16 +176,16 @@ export const WithColumnHiding = (args: Partial<ITableProps>) => {
     <>
       <div>
         <input
-          checked={allColumns.every((c) => !c.isHidden)}
+          checked={allColumns.every((c) => !c.hidden)}
           onClick={toggleHideAll}
           type="checkbox"
           id="all"
         />
         <label htmlFor="all">All</label>
-        {allColumns.map(({ id, label, toggleHide, isHidden }) => (
+        {allColumns.map(({ id, label, toggleHide, hidden }) => (
           <div key={id}>
             <input
-              checked={!isHidden}
+              checked={!hidden}
               onClick={toggleHide}
               type="checkbox"
               id={id}

--- a/src/hooks/useTable/useTable.ts
+++ b/src/hooks/useTable/useTable.ts
@@ -82,7 +82,7 @@ function useTable<
     useReducer(tableReducer, {
       currentPage: pagination?.initialPage || 0,
       pageSize: pagination?.pageSize || 10,
-      visibleColumns: columns?.map((c) => c.id) ?? [],
+      visibleColumns: columns?.filter((c) => !c.hidden).map((c) => c.id) ?? [],
       filters: [],
       sort: sorting?.default ?? [],
     });
@@ -133,7 +133,7 @@ function useTable<
         ...c,
         toggleHide: () =>
           dispatch({ type: "toggleVisibleItem", payload: c.id }),
-        isHidden: !visibleColumns.includes(c.id),
+        hidden: !visibleColumns.includes(c.id),
         availableFilterOperators:
           c?.availableFilterOperators ?? (c?.type && availableFilters[c.type]),
       })),

--- a/src/hooks/useTable/useTable.types.ts
+++ b/src/hooks/useTable/useTable.types.ts
@@ -19,7 +19,7 @@ import { Column, Filter, Sort } from "../../types";
 type AllColumns = Array<
   Column & {
     toggleHide: () => void;
-    isHidden: boolean;
+    hidden: boolean;
   }
 >;
 

--- a/src/types/column.ts
+++ b/src/types/column.ts
@@ -36,4 +36,5 @@ export type Column = {
   type?: ColumnType;
   availableFilterOperators?: Array<FilterOperator>;
   sortable?: boolean;
+  hidden?: boolean;
 };


### PR DESCRIPTION
## Description

Hide table columns when `hidden` is set to `true`.

Notes: remove `isHidden` in favour of `hidden`