### PR TITLE
fix: improvements and exports

### DIFF
--- a/.changeset/tidy-terms-trade.md
+++ b/.changeset/tidy-terms-trade.md
@@ -1,0 +1,5 @@
+---
+"@arkejs/table": minor
+---
+
+table types export and improvements

--- a/apps/docs/content/docs/api/table.mdx
+++ b/apps/docs/content/docs/api/table.mdx
@@ -13,7 +13,7 @@ A list of actions to be displayed for each of the table rows.
 ## `columns`
 
 ```ts
-columns: Column[];
+columns: TableColumn[];
 ```
 
 A list of columns to be displayed in the table.
@@ -63,7 +63,7 @@ A function to be called when a row is expanded.
 ## `renderHeader`
 
 ```ts
-renderHeader?: (column: Column) => ReactNode;
+renderHeader?: (column: TableColumn) => ReactNode;
 ```
 
 A function to render the header of the table.

--- a/apps/docs/content/docs/api/table.mdx
+++ b/apps/docs/content/docs/api/table.mdx
@@ -39,7 +39,7 @@ The data to be displayed in the table.
 ## `expandedRows`
 
 ```ts
-expandedRows: ExpandedState;
+expandedRows: TableExpandedState;
 ```
 
 The state of the expanded rows.

--- a/apps/docs/examples/custom-sort.tsx
+++ b/apps/docs/examples/custom-sort.tsx
@@ -16,7 +16,7 @@ function CustomSort() {
       <div className="flex gap-4">
         <button
           className="btn btn--primary"
-          onClick={() => setSort([{ columnId: "id", type: "asc" }])}
+          onClick={() => setSort([{ key: "id", type: "asc" }])}
         >
           Sort by ID
         </button>

--- a/apps/docs/examples/expandable-state.tsx
+++ b/apps/docs/examples/expandable-state.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
-import { TableColumn, ExpandedState, Table } from "@arkejs/table";
+import { TableColumn, TableExpandedState, Table } from "@arkejs/table";
 import { default as mockColumns } from "@/examples/mocks/columns";
 import data from "@/examples/mocks/data";
 
 function ExpandableState() {
-  const [expandedRows, setExpandedRows] = useState<ExpandedState>({});
+  const [expandedRows, setExpandedRows] = useState<TableExpandedState>({});
 
   const columns: TableColumn[] = [
     {

--- a/apps/docs/examples/expandable-state.tsx
+++ b/apps/docs/examples/expandable-state.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from "react";
-import { Column, ExpandedState, Table } from "@arkejs/table";
+import { TableColumn, ExpandedState, Table } from "@arkejs/table";
 import { default as mockColumns } from "@/examples/mocks/columns";
 import data from "@/examples/mocks/data";
 
 function ExpandableState() {
   const [expandedRows, setExpandedRows] = useState<ExpandedState>({});
 
-  const columns: Column[] = [
+  const columns: TableColumn[] = [
     {
       id: "toggle",
       label: "toggle",

--- a/apps/docs/examples/expandable.tsx
+++ b/apps/docs/examples/expandable.tsx
@@ -1,9 +1,9 @@
-import { Column, Table, useTable } from "@arkejs/table";
+import { TableColumn, Table, useTable } from "@arkejs/table";
 import { default as mockColumns } from "@/examples/mocks/columns";
 import data from "@/examples/mocks/data";
 
 function Expandable() {
-  const columns: Column[] = [
+  const columns: TableColumn[] = [
     {
       id: "toggle",
       label: "toggle",

--- a/apps/docs/examples/filtering.tsx
+++ b/apps/docs/examples/filtering.tsx
@@ -22,7 +22,7 @@ function Filtering() {
                 // @ts-ignore
                 const value = e.target?.value?.value;
                 if (operator && value) {
-                  setFilters([...filters, { operator, value, columnId: c.id }]);
+                  setFilters([...filters, { operator, value, key: c.id }]);
                   // @ts-ignore
                   e.target.reset();
                 }

--- a/apps/docs/examples/mocks/columns.ts
+++ b/apps/docs/examples/mocks/columns.ts
@@ -1,6 +1,6 @@
-import { Column } from "@arkejs/table";
+import { TableColumn } from "@arkejs/table";
 
-const columns: Column[] = [
+const columns: TableColumn[] = [
   { label: "ID", id: "id" },
   { label: "Name", id: "first_name", type: "string" },
   {

--- a/apps/storybook/src/mocks/mockColumns.ts
+++ b/apps/storybook/src/mocks/mockColumns.ts
@@ -1,6 +1,6 @@
-import { Column } from "@arkejs/table";
+import { TableColumn } from "@arkejs/table";
 
-const mockColumns: Column[] = [
+const mockColumns: TableColumn[] = [
   { label: "ID", id: "id" },
   { label: "Name", id: "first_name", type: "string" },
   {

--- a/apps/storybook/src/stories/Table.stories.tsx
+++ b/apps/storybook/src/stories/Table.stories.tsx
@@ -1,5 +1,5 @@
 import {
-  Column,
+  TableColumn,
   ExpandedState,
   ITableProps,
   Table,
@@ -218,9 +218,9 @@ export const WithMultipleColumnHiding = (args: Partial<ITableProps>) => {
   const { tableProps, allColumns, toggleHide } = useTable({
     columns: mockColumns,
   });
-  const [tempColumns, setTempColumns] = useState<Column[]>(allColumns);
+  const [tempColumns, setTempColumns] = useState<TableColumn[]>(allColumns);
 
-  const handleChange = (column: Column) => {
+  const handleChange = (column: TableColumn) => {
     setTempColumns((prevState) =>
       prevState.map((c) =>
         c.id === column.id ? { ...c, hidden: !c.hidden } : c
@@ -332,7 +332,7 @@ export const ExpandableState = (args: Partial<ITableProps>) => {
   const data = mockData;
   const pageSize = 10;
 
-  const columns: Column[] = [
+  const columns: TableColumn[] = [
     {
       id: "toggle",
       label: "toggle",
@@ -385,7 +385,7 @@ export const ExpandableUseTable = (args: Partial<ITableProps>) => {
   const data = mockData;
   const pageSize = 10;
 
-  const columns: Column[] = [
+  const columns: TableColumn[] = [
     {
       id: "toggle",
       label: "toggle",

--- a/apps/storybook/src/stories/Table.stories.tsx
+++ b/apps/storybook/src/stories/Table.stories.tsx
@@ -1,6 +1,6 @@
 import {
   TableColumn,
-  ExpandedState,
+  TableExpandedState,
   ITableProps,
   Table,
   useTable,
@@ -328,7 +328,7 @@ export const WithActions = (args: Partial<ITableProps>) => {
 };
 
 export const ExpandableState = (args: Partial<ITableProps>) => {
-  const [expandedRows, setExpandedRows] = useState<ExpandedState>({});
+  const [expandedRows, setExpandedRows] = useState<TableExpandedState>({});
   const data = mockData;
   const pageSize = 10;
 

--- a/apps/storybook/src/stories/Table.stories.tsx
+++ b/apps/storybook/src/stories/Table.stories.tsx
@@ -166,7 +166,7 @@ export const WithCustomSorting = (args: Partial<ITableProps>) => {
 
   return (
     <>
-      <button onClick={() => setSort([{ columnId: "id", type: "asc" }])}>
+      <button onClick={() => setSort([{ key: "id", type: "asc" }])}>
         Sort by ID
       </button>
       <button onClick={() => setSort([])}>Reset</button>
@@ -272,7 +272,7 @@ export const WithFilter = (args: Partial<ITableProps>) => {
                 // @ts-ignore
                 const value = e.target?.value?.value;
                 if (operator && value) {
-                  setFilters([...filters, { operator, value, columnId: c.id }]);
+                  setFilters([...filters, { operator, value, key: c.id }]);
                   // @ts-ignore
                   e.target.reset();
                 }

--- a/packages/table/src/components/Table/Table.tsx
+++ b/packages/table/src/components/Table/Table.tsx
@@ -19,7 +19,7 @@ import { Pagination } from "../Pagination";
 import { Fragment, ReactNode, useCallback, useMemo } from "react";
 import pagination from "../Pagination/Pagination";
 import { useTableConfig } from "../TableConfigProvider/TableConfigProvider";
-import { Action, Column } from "../../types";
+import { Action, TableColumn } from "../../types";
 import { TableHeadCell } from "../TableHeadCell";
 
 const getPagedIndex = (index: number, currentPage: number, pageSize = 0) =>
@@ -52,7 +52,7 @@ function Table({
   );
 
   const renderData = useCallback(
-    (column: Column, row: Record<string, unknown>, index: number) => {
+    (column: TableColumn, row: Record<string, unknown>, index: number) => {
       if (column.render) {
         return column.render(row, {
           handleExpandRow: () =>

--- a/packages/table/src/components/Table/Table.types.ts
+++ b/packages/table/src/components/Table/Table.types.ts
@@ -15,18 +15,18 @@
  */
 
 import { CSSProperties, ReactNode } from "react";
-import { Action, Column, TableComponents } from "../../types";
+import { Action, TableColumn, TableComponents } from "../../types";
 import { IUseTableForwardedProps } from "../../hooks";
 
 type ITableProps = {
   /**
    * Table Columns
    */
-  columns: Omit<Column, "availableFilterOperators">[];
+  columns: Omit<TableColumn, "availableFilterOperators">[];
   data: Record<string, unknown>[];
   actions?: ActionsConfig;
   noResult?: ReactNode;
-  renderHeader?: (column: Column) => ReactNode;
+  renderHeader?: (column: TableColumn) => ReactNode;
   components?: TableComponents;
 } & Partial<IUseTableForwardedProps<any, any, any>>;
 

--- a/packages/table/src/components/Table/Table.types.ts
+++ b/packages/table/src/components/Table/Table.types.ts
@@ -31,7 +31,7 @@ type ITableProps = {
 } & Partial<IUseTableForwardedProps<any, any, any>>;
 
 interface ActionsConfig {
-  label: string;
+  label: string | ReactNode;
   position?: "start" | "end";
   className?: string;
   style?: CSSProperties;

--- a/packages/table/src/components/TableHeadCell/TableHeadCell.tsx
+++ b/packages/table/src/components/TableHeadCell/TableHeadCell.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Column } from "../../types";
+import { TableColumn } from "../../types";
 import { ISortData } from "../../hooks";
 import { useCallback, useMemo } from "react";
 
@@ -52,7 +52,7 @@ function TableHeadCell({
   setSort,
   sortType,
   renderHeader,
-}: Column & Partial<ISortData>) {
+}: TableColumn & Partial<ISortData>) {
   const isSortingEnabled = sortable && sortType !== "custom";
 
   const columnSort = useMemo(() => {

--- a/packages/table/src/components/TableHeadCell/TableHeadCell.tsx
+++ b/packages/table/src/components/TableHeadCell/TableHeadCell.tsx
@@ -57,23 +57,23 @@ function TableHeadCell({
 
   const columnSort = useMemo(() => {
     if (isSortingEnabled) {
-      return sort?.find((s) => s.columnId === id);
+      return sort?.find((s) => s.key === id);
     }
     return undefined;
   }, [sort, isSortingEnabled, id]);
 
   const handleChangeSort = useCallback(() => {
     if (isSortingEnabled) {
-      const newSort = sort?.filter((s) => s.columnId !== id) ?? [];
+      const newSort = sort?.filter((s) => s.key !== id) ?? [];
 
       if (columnSort) {
         if (columnSort.type === "asc") {
-          setSort?.([...newSort, { columnId: id, type: "desc" }]);
+          setSort?.([...newSort, { key: id, type: "desc" }]);
         } else {
           setSort?.(newSort);
         }
       } else {
-        setSort?.([...newSort, { columnId: id, type: "asc" }]);
+        setSort?.([...newSort, { key: id, type: "asc" }]);
       }
     }
   }, [columnSort, id, setSort, sort, isSortingEnabled]);

--- a/packages/table/src/hooks/useTable/useTable.ts
+++ b/packages/table/src/hooks/useTable/useTable.ts
@@ -16,7 +16,7 @@
 
 import { useReducer, useState } from "react";
 import usePagination from "../usePagination";
-import type { Column, Filter, TableSort } from "../../types";
+import type { TableColumn, Filter, TableSort } from "../../types";
 import type {
   IPaginationConfig,
   ISortConfig,
@@ -163,7 +163,7 @@ function useTable<
           c?.availableFilterOperators ??
           (c?.type && availableFilters?.[c.type]),
       })),
-      toggleHide: (columns: Column[]) =>
+      toggleHide: (columns: TableColumn[]) =>
         dispatch({ type: "toggleMultipleVisibleItems", payload: columns }),
       toggleHideAll: () =>
         dispatch({ type: "toggleAllVisibleItems", payload: columns }),

--- a/packages/table/src/hooks/useTable/useTable.ts
+++ b/packages/table/src/hooks/useTable/useTable.ts
@@ -16,7 +16,7 @@
 
 import { useReducer, useState } from "react";
 import usePagination from "../usePagination";
-import type { TableColumn, Filter, TableSort } from "../../types";
+import type { TableColumn, TableFilter, TableSort } from "../../types";
 import type {
   IPaginationConfig,
   ISortConfig,
@@ -170,7 +170,7 @@ function useTable<
       columns: columns
         .filter((c) => visibleColumns.includes(c.id))
         .map((column) => ({ ...column, sortable: column?.sortable ?? true })),
-      setFilters: (filters: Filter[]) =>
+      setFilters: (filters: TableFilter[]) =>
         dispatch({ type: "setFilters", payload: filters }),
       resetAllFilters: () =>
         dispatch({ type: "resetAllFilters", payload: undefined }),

--- a/packages/table/src/hooks/useTable/useTable.ts
+++ b/packages/table/src/hooks/useTable/useTable.ts
@@ -16,7 +16,7 @@
 
 import { useReducer, useState } from "react";
 import usePagination from "../usePagination";
-import type { Column, Filter, Sort } from "../../types";
+import type { Column, Filter, TableSort } from "../../types";
 import type {
   IPaginationConfig,
   ISortConfig,
@@ -181,7 +181,7 @@ function useTable<
         ...data,
         sort,
         sortable: !!config?.sorting?.sortable,
-        setSort: (sort: Sort[]) => dispatch({ type: "setSort", payload: sort }),
+        setSort: (sort: TableSort[]) => dispatch({ type: "setSort", payload: sort }),
         sortType: sorting.type,
       };
     }

--- a/packages/table/src/hooks/useTable/useTable.types.ts
+++ b/packages/table/src/hooks/useTable/useTable.types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Column, ExpandedState, Filter, Sort } from "../../types";
+import { Column, ExpandedState, Filter, TableSort } from "../../types";
 
 type AllColumns = Array<
   Column & {
@@ -32,9 +32,9 @@ type IPaginationConfig = {
   type?: "custom";
 };
 
-type ISortConfig = { default?: Sort[]; sortable?: boolean; type?: "custom" };
+type ISortConfig = { default?: TableSort[]; sortable?: boolean; type?: "custom" };
 
-interface IUseTableConfig<Pagination, Sort, Expandable> {
+interface IUseTableConfig<Pagination, TableSort, Expandable> {
   pagination?: Pagination;
   columns: Column[];
   sorting?: ISortConfig;
@@ -64,8 +64,8 @@ type IColumnsData = {
 };
 
 type ISortData = {
-  sort: Sort[];
-  setSort: (sort: Sort[]) => void;
+  sort: TableSort[];
+  setSort: (sort: TableSort[]) => void;
   sortable: boolean;
   sortType?: "custom";
 };
@@ -74,30 +74,30 @@ type IExpandableData = {
   expandedRows: ExpandedState;
 };
 
-type IUseTableResult<Pagination, Sort, Expandable> =
+type IUseTableResult<Pagination, TableSort, Expandable> =
   (Pagination extends undefined ? undefined : IPaginationData) &
-    (Sort extends undefined ? undefined : ISortData) &
+    (TableSort extends undefined ? undefined : ISortData) &
     (Expandable extends true ? IExpandableData : undefined) &
     IColumnsData;
 
-type IUseTableForwardedProps<Pagination, Sort, Expandable> = IUseTableResult<
+type IUseTableForwardedProps<Pagination, TableSort, Expandable> = IUseTableResult<
   Pagination,
-  Sort,
+  TableSort,
   Expandable
 > & {
   onExpandRow?: (index: number) => void;
 };
 
-type IUseTableData<Pagination, Sort, Expandable> = {
-  tableProps: IUseTableForwardedProps<Pagination, Sort, Expandable>;
-} & IUseTableResult<Pagination, Sort, Expandable>;
+type IUseTableData<Pagination, TableSort, Expandable> = {
+  tableProps: IUseTableForwardedProps<Pagination, TableSort, Expandable>;
+} & IUseTableResult<Pagination, TableSort, Expandable>;
 
 type TableState = {
   currentPage: number;
   pageSize: number;
   visibleColumns: string[];
   filters: Filter[];
-  sort: Sort[];
+  sort: TableSort[];
   expandedRows: ExpandedState;
   initialFilters: Filter[];
 };
@@ -113,7 +113,7 @@ type UseTableAction =
   | { type: "refresh"; payload: Partial<TableState> }
   | { type: "setFilters"; payload: Filter[] }
   | { type: "resetAllFilters"; payload: undefined }
-  | { type: "setSort"; payload: Sort[] }
+  | { type: "setSort"; payload: TableSort[] }
   | { type: "setExpandedRows"; payload: number };
 
 export {

--- a/packages/table/src/hooks/useTable/useTable.types.ts
+++ b/packages/table/src/hooks/useTable/useTable.types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { TableColumn, ExpandedState, TableFilter, TableSort } from "../../types";
+import { TableColumn, TableExpandedState, TableFilter, TableSort } from "../../types";
 
 type AllColumns = Array<
   TableColumn & {
@@ -71,7 +71,7 @@ type ISortData = {
 };
 
 type IExpandableData = {
-  expandedRows: ExpandedState;
+  expandedRows: TableExpandedState;
 };
 
 type IUseTableResult<Pagination, TableSort, Expandable> =
@@ -98,7 +98,7 @@ type TableState = {
   visibleColumns: string[];
   filters: TableFilter[];
   sort: TableSort[];
-  expandedRows: ExpandedState;
+  expandedRows: TableExpandedState;
   initialFilters: TableFilter[];
 };
 

--- a/packages/table/src/hooks/useTable/useTable.types.ts
+++ b/packages/table/src/hooks/useTable/useTable.types.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { Column, ExpandedState, Filter, TableSort } from "../../types";
+import { TableColumn, ExpandedState, Filter, TableSort } from "../../types";
 
 type AllColumns = Array<
-  Column & {
+  TableColumn & {
     toggleHide: () => void;
     hidden: boolean;
   }
@@ -36,7 +36,7 @@ type ISortConfig = { default?: TableSort[]; sortable?: boolean; type?: "custom" 
 
 interface IUseTableConfig<Pagination, TableSort, Expandable> {
   pagination?: Pagination;
-  columns: Column[];
+  columns: TableColumn[];
   sorting?: ISortConfig;
   expandable?: Expandable;
   initialFilters?: Filter[];
@@ -56,8 +56,8 @@ interface IPaginationData {
 type IColumnsData = {
   allColumns: AllColumns;
   toggleHideAll: () => void;
-  toggleHide: (columns: Column[]) => void;
-  columns: Array<Omit<Column, "availableFilterOperators">>;
+  toggleHide: (columns: TableColumn[]) => void;
+  columns: Array<Omit<TableColumn, "availableFilterOperators">>;
   resetAllFilters: () => void;
   setFilters: (filters: Filter[]) => void;
   filters: Array<Filter>;
@@ -108,8 +108,8 @@ type UseTableAction =
       payload: number;
     }
   | { type: "toggleVisibleItem"; payload: string }
-  | { type: "toggleMultipleVisibleItems"; payload: Column[] }
-  | { type: "toggleAllVisibleItems"; payload: Column[] }
+  | { type: "toggleMultipleVisibleItems"; payload: TableColumn[] }
+  | { type: "toggleAllVisibleItems"; payload: TableColumn[] }
   | { type: "refresh"; payload: Partial<TableState> }
   | { type: "setFilters"; payload: Filter[] }
   | { type: "resetAllFilters"; payload: undefined }

--- a/packages/table/src/hooks/useTable/useTable.types.ts
+++ b/packages/table/src/hooks/useTable/useTable.types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { TableColumn, ExpandedState, Filter, TableSort } from "../../types";
+import { TableColumn, ExpandedState, TableFilter, TableSort } from "../../types";
 
 type AllColumns = Array<
   TableColumn & {
@@ -39,7 +39,7 @@ interface IUseTableConfig<Pagination, TableSort, Expandable> {
   columns: TableColumn[];
   sorting?: ISortConfig;
   expandable?: Expandable;
-  initialFilters?: Filter[];
+  initialFilters?: TableFilter[];
 }
 
 interface IPaginationData {
@@ -59,8 +59,8 @@ type IColumnsData = {
   toggleHide: (columns: TableColumn[]) => void;
   columns: Array<Omit<TableColumn, "availableFilterOperators">>;
   resetAllFilters: () => void;
-  setFilters: (filters: Filter[]) => void;
-  filters: Array<Filter>;
+  setFilters: (filters: TableFilter[]) => void;
+  filters: Array<TableFilter>;
 };
 
 type ISortData = {
@@ -96,10 +96,10 @@ type TableState = {
   currentPage: number;
   pageSize: number;
   visibleColumns: string[];
-  filters: Filter[];
+  filters: TableFilter[];
   sort: TableSort[];
   expandedRows: ExpandedState;
-  initialFilters: Filter[];
+  initialFilters: TableFilter[];
 };
 
 type UseTableAction =
@@ -111,7 +111,7 @@ type UseTableAction =
   | { type: "toggleMultipleVisibleItems"; payload: TableColumn[] }
   | { type: "toggleAllVisibleItems"; payload: TableColumn[] }
   | { type: "refresh"; payload: Partial<TableState> }
-  | { type: "setFilters"; payload: Filter[] }
+  | { type: "setFilters"; payload: TableFilter[] }
   | { type: "resetAllFilters"; payload: undefined }
   | { type: "setSort"; payload: TableSort[] }
   | { type: "setExpandedRows"; payload: number };

--- a/packages/table/src/types/column.ts
+++ b/packages/table/src/types/column.ts
@@ -17,7 +17,7 @@
 import { CSSProperties, ReactNode } from "react";
 import { FilterOperator } from "./filters";
 
-export type Column = {
+export type TableColumn = {
   id: string;
   label: string;
   renderHeader?: () => string | number | ReactNode;

--- a/packages/table/src/types/components.ts
+++ b/packages/table/src/types/components.ts
@@ -1,10 +1,10 @@
-import { Column } from "./column";
+import { TableColumn } from "./column";
 import { ReactElement } from "react";
 
 type TableComponents = Partial<
   Record<
     string,
-    (value: any, rowData: Record<string, any>, column: Column) => ReactElement
+    (value: any, rowData: Record<string, any>, column: TableColumn) => ReactElement
   >
 > & {
   ExpandedRow?: (rowData: Record<string, any>) => ReactElement;

--- a/packages/table/src/types/expandable.ts
+++ b/packages/table/src/types/expandable.ts
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 
-type ExpandedState = Record<number, boolean>;
+type TableExpandedState = Record<number, boolean>;
 
-export type { ExpandedState };
+export type { TableExpandedState };

--- a/packages/table/src/types/filters.ts
+++ b/packages/table/src/types/filters.ts
@@ -32,7 +32,7 @@ export enum FilterOperator {
 }
 
 export type TableFilter = {
-  columnId: string;
+  key: string;
   operator: FilterOperator;
   value: string | number;
 };

--- a/packages/table/src/types/filters.ts
+++ b/packages/table/src/types/filters.ts
@@ -31,7 +31,7 @@ export enum FilterOperator {
   BETWEEN = "between",
 }
 
-export type Filter = {
+export type TableFilter = {
   columnId: string;
   operator: FilterOperator;
   value: string | number;

--- a/packages/table/src/types/sort.ts
+++ b/packages/table/src/types/sort.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-type Sort = {
+type TableSort = {
   type: "asc" | "desc";
   columnId: string;
 };
 
-export { Sort };
+export { TableSort };

--- a/packages/table/src/types/sort.ts
+++ b/packages/table/src/types/sort.ts
@@ -16,7 +16,7 @@
 
 type TableSort = {
   type: "asc" | "desc";
-  columnId: string;
+  key: string;
 };
 
 export { TableSort };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
@@ -55,7 +55,7 @@ importers:
         version: 2.5.1
       turbo:
         specifier: latest
-        version: 1.10.16
+        version: 1.11.3
 
   apps/docs:
     dependencies:
@@ -11862,64 +11862,64 @@ packages:
       yargs: 17.7.2
     dev: false
 
-  /turbo-darwin-64@1.10.16:
-    resolution: {integrity: sha512-+Jk91FNcp9e9NCLYlvDDlp2HwEDp14F9N42IoW3dmHI5ZkGSXzalbhVcrx3DOox3QfiNUHxzWg4d7CnVNCuuMg==}
+  /turbo-darwin-64@1.11.3:
+    resolution: {integrity: sha512-IsOOg2bVbIt3o/X8Ew9fbQp5t1hTHN3fGNQYrPQwMR2W1kIAC6RfbVD4A9OeibPGyEPUpwOH79hZ9ydFH5kifw==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /turbo-darwin-arm64@1.10.16:
-    resolution: {integrity: sha512-jqGpFZipIivkRp/i+jnL8npX0VssE6IAVNKtu573LXtssZdV/S+fRGYA16tI46xJGxSAivrZ/IcgZrV6Jk80bw==}
+  /turbo-darwin-arm64@1.11.3:
+    resolution: {integrity: sha512-FsJL7k0SaPbJzI/KCnrf/fi3PgCDCjTliMc/kEFkuWVA6Httc3Q4lxyLIIinz69q6JTx8wzh6yznUMzJRI3+dg==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: false
     optional: true
 
-  /turbo-linux-64@1.10.16:
-    resolution: {integrity: sha512-PpqEZHwLoizQ6sTUvmImcRmACyRk9EWLXGlqceogPZsJ1jTRK3sfcF9fC2W56zkSIzuLEP07k5kl+ZxJd8JMcg==}
+  /turbo-linux-64@1.11.3:
+    resolution: {integrity: sha512-SvW7pvTVRGsqtSkII5w+wriZXvxqkluw5FO/MNAdFw0qmoov+PZ237+37/NgArqE3zVn1GX9P6nUx9VO+xcQAg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /turbo-linux-arm64@1.10.16:
-    resolution: {integrity: sha512-TMjFYz8to1QE0fKVXCIvG/4giyfnmqcQIwjdNfJvKjBxn22PpbjeuFuQ5kNXshUTRaTJihFbuuCcb5OYFNx4uw==}
+  /turbo-linux-arm64@1.11.3:
+    resolution: {integrity: sha512-YhUfBi1deB3m+3M55X458J6B7RsIS7UtM3P1z13cUIhF+pOt65BgnaSnkHLwETidmhRh8Dl3GelaQGrB3RdCDw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: false
     optional: true
 
-  /turbo-windows-64@1.10.16:
-    resolution: {integrity: sha512-+jsf68krs0N66FfC4/zZvioUap/Tq3sPFumnMV+EBo8jFdqs4yehd6+MxIwYTjSQLIcpH8KoNMB0gQYhJRLZzw==}
+  /turbo-windows-64@1.11.3:
+    resolution: {integrity: sha512-s+vEnuM2TiZuAUUUpmBHDr6vnNbJgj+5JYfnYmVklYs16kXh+EppafYQOAkcRIMAh7GjV3pLq5/uGqc7seZeHA==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: false
     optional: true
 
-  /turbo-windows-arm64@1.10.16:
-    resolution: {integrity: sha512-sKm3hcMM1bl0B3PLG4ifidicOGfoJmOEacM5JtgBkYM48ncMHjkHfFY7HrJHZHUnXM4l05RQTpLFoOl/uIo2HQ==}
+  /turbo-windows-arm64@1.11.3:
+    resolution: {integrity: sha512-ZR5z5Zpc7cASwfdRAV5yNScCZBsgGSbcwiA/u3farCacbPiXsfoWUkz28iyrx21/TRW0bi6dbsB2v17swa8bjw==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: false
     optional: true
 
-  /turbo@1.10.16:
-    resolution: {integrity: sha512-2CEaK4FIuSZiP83iFa9GqMTQhroW2QryckVqUydmg4tx78baftTOS0O+oDAhvo9r9Nit4xUEtC1RAHoqs6ZEtg==}
+  /turbo@1.11.3:
+    resolution: {integrity: sha512-RCJOUFcFMQNIGKSjC9YmA5yVP1qtDiBA0Lv9VIgrXraI5Da1liVvl3VJPsoDNIR9eFMyA/aagx1iyj6UWem5hA==}
     hasBin: true
     optionalDependencies:
-      turbo-darwin-64: 1.10.16
-      turbo-darwin-arm64: 1.10.16
-      turbo-linux-64: 1.10.16
-      turbo-linux-arm64: 1.10.16
-      turbo-windows-64: 1.10.16
-      turbo-windows-arm64: 1.10.16
+      turbo-darwin-64: 1.11.3
+      turbo-darwin-arm64: 1.11.3
+      turbo-linux-64: 1.11.3
+      turbo-linux-arm64: 1.11.3
+      turbo-windows-64: 1.11.3
+      turbo-windows-arm64: 1.11.3
     dev: false
 
   /tween-functions@1.2.0:


### PR DESCRIPTION
## Description

- Use `key` instead of `columnId` to unify @arkejs/client and @arkejs/table 
- Use `Table` prefix on export types to avoid conflits with @arkejs/client
- Extend label actions with ReactNode