### PR TITLE
fix: table actions use html button type

### DIFF
--- a/packages/table/src/components/table.tsx
+++ b/packages/table/src/components/table.tsx
@@ -222,7 +222,7 @@ const TableAction = ({
   data,
 }: Action & { data: Record<string, unknown> }) => {
   return (
-    <button onClick={() => onClick?.(data)}>
+    <button type="button" onClick={() => onClick?.(data)}>
       {typeof content === "function" ? content(data) : content}
     </button>
   );


### PR DESCRIPTION
## Description

Add type `button` on action button, if for some reason the table is inside a form, it submit the form.
